### PR TITLE
fix: flatten IPhoneFrame layout to fix mobile image not rendering

### DIFF
--- a/src/lib/components/ui/iPhoneFrame.svelte
+++ b/src/lib/components/ui/iPhoneFrame.svelte
@@ -5,33 +5,30 @@
     import iPhoneFrame from "$lib/assets/Apple iPhone 16 Pro White Titanium.svg";
 </script>
 
-<div class="relative w-[93%] h-[93%] max-w-xs mx-auto">
-    <!-- iPhone Frame (on top) -->
-    <div class="relative flex justify-center items-center">
+<div class="relative w-[93%] max-w-xs mx-auto">
+    <!-- iPhone Frame (sets component dimensions) -->
+    <img
+        src={iPhoneFrame}
+        alt="iPhone 16 Pro frame"
+        class="w-full h-auto relative z-[23]"
+    />
+    <!-- Wallpaper image -->
+    <img
+        src={imageUrl}
+        {alt}
+        class="absolute w-[96%] h-[97%] inset-0 m-auto object-cover z-[20] rounded-[28px]"
+    />
+    <!-- iPhone Dock -->
+    <div
+        class="absolute bottom-[5%] left-1/2 transform -translate-x-1/2 w-[60%] h-auto z-[22]"
+    >
+        <div
+            class="absolute inset-0 bg-white/20 backdrop-blur-sm rounded-2xl"
+        ></div>
         <img
-            src={iPhoneFrame}
-            alt="iPhone 16 Pro frame"
-            class="object-contain z-[23] w-full h-full"
+            src={iPhoneDock}
+            alt="iPhone dock"
+            class="relative w-full h-auto"
         />
-        <div>
-            <img
-                src={imageUrl}
-                {alt}
-                class="absolute w-[96%] h-[97%] inset-0 m-auto object-cover z-[20] rounded-[28px]"
-            />
-            <!-- iPhone Dock -->
-            <div
-                class="absolute bottom-[5%] left-1/2 transform -translate-x-1/2 w-[60%] h-auto z-[22]"
-            >
-                <div
-                    class="absolute inset-0 bg-white/20 backdrop-blur-sm rounded-2xl"
-                ></div>
-                <img
-                    src={iPhoneDock}
-                    alt="iPhone dock"
-                    class="relative w-full h-auto"
-                />
-            </div>
-        </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Flattened the IPhoneFrame component layout to fix mobile wallpaper images not rendering on initial page load
- The wallpaper image and dock were inside a bare `<div>` that collapsed to 0x0 (both children absolute-positioned), nested in a flex container with circular height dependencies
- Restructured to match MacBookFrame's approach: SVG sets dimensions via `w-full h-auto`, wallpaper and dock are absolute-positioned to the root

## Test plan
- [x] Added E2E test verifying mobile image renders on initial load with non-zero dimensions
- [x] Fixed existing test selectors for strict mode violations and exact button matching
- [x] All 10 wallpaper tests pass on Chromium